### PR TITLE
Updated to latest zig

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/s2s"]
-	path = vendor/s2s
-	url = https://github.com/ziglibs/s2s

--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,16 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const mode = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const local_module = b.addModule("antiphony", .{
+        .root_source_file = .{ .path = "src/antiphony.zig" },
+    });
+    const s2s_dep = b.dependency("s2s", .{});
+    const s2s_mod = s2s_dep.module("s2s");
+    local_module.addImport("s2s",s2s_mod );
 
     const linux_example = b.addExecutable(.{
         .name = "socketpair-example",
@@ -14,18 +20,9 @@ pub fn build(b: *std.build.Builder) void {
         .optimize = mode,
         .target = target,
     });
-    linux_example.addAnonymousModule("antiphony", .{
-        .source_file = .{ .path = "src/antiphony.zig" },
-        .dependencies = &.{
-            .{
-                .name = "s2s",
-                .module = b.addModule("s2s", .{
-                    .source_file = .{ .path = "vendor/s2s/s2s.zig" },
-                }),
-            }
-        },
-    });
-    linux_example.install();
+    linux_example.root_module.addImport("antiphony", local_module);
+
+    b.installArtifact(linux_example);
 
     const main_tests = b.addTest(.{
         .name = "antiphony",
@@ -35,9 +32,7 @@ pub fn build(b: *std.build.Builder) void {
         .target = target,
         .optimize = mode,
     });
-    main_tests.addAnonymousModule("s2s", .{
-        .source_file = .{ .path = "vendor/s2s/s2s.zig" },
-    });
+    main_tests.root_module.addImport("s2s", s2s_mod);
 
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = "antiphony",
+    .version = "0.0.0",
+    .dependencies = .{
+        .s2s = .{
+            .url = "https://github.com/ziglibs/s2s/archive/b30205d5e9204899fb6d0fdf28d00ed4d18fe9c9.tar.gz",
+            .hash = "12202c39c98f05041f1052c268132669dbfcda87e4dbb0353cd84a6070924c8ac0e3",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/examples/linux.zig
+++ b/examples/linux.zig
@@ -68,7 +68,7 @@ fn hostImplementation(file: std.fs.File) !void {
         }
 
         pub fn createCounter(self: *Self) CreateError!u32 {
-            const index = @truncate(u32, self.counters.items.len);
+            const index : u32 = @truncate(self.counters.items.len);
             try self.counters.append(0);
             return index;
         }


### PR DESCRIPTION
- Use the package manager to get the s2s dep
- update to latest build system
- update reader/writer syntax for reading little endian values
- changed to latests builtins (`@intFromEnum`, `@enumFromInt`, `@intFromFloat`, use either `@as` or a type definition for the variable for type resolution so truncate an other builtins works, use `@max` instead of std.math.max)